### PR TITLE
Readme update + quick fix for file_get_contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 <a href="https://github.com/alexcroox/R3-Web/releases/latest">
     <img src="https://img.shields.io/github/release/alexcroox/R3-Web.svg" alt="Project Version">
-</a>   
-    
+</a>
+
 <a href="https://raw.githubusercontent.com/alexcroox/R3-Web/master/LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-red.svg" alt="Project License">
 </a>
@@ -35,6 +35,10 @@ An exact mirror of this repo [can be viewed here](https://aar.ark-group.org) whi
 2. Download the [latest web release](https://github.com/alexcroox/R3-Web/releases/latest)
 3. Rename `config.template.php` to `config.php`, pay close attention to `DB_*`, `WEB_PATH` and timezone configurations
 4. Upload the files to your web server which matches the URL in `WEB_PATH` in `config.php`. Take note of `/.htaccess` in the download that may be hidden on your system before you upload.
+5. _(linux specifc)_ give the `cache` directory permissions for your web-server user account:
+```
+chown www-data:www-data -R cache/
+```
 
 ### Important information to get the most from R3
 
@@ -56,5 +60,5 @@ You can find me (Titan) on the [R3 Discord](https://discord.gg/qcE3dRP) or feel 
 
 ### Why not x framework/language
 
-In an ideal world I'd be using web sockets and node to stream from the game server straight to a flat json file, and to the browser. 
+In an ideal world I'd be using web sockets and node to stream from the game server straight to a flat json file, and to the browser.
 However the goal is to allow Arma 3 server admins to be able to run this and contribute. PHP + MySQL is the most common setup these administrators (with potentially limited sysadmin knowledge or sudo access) will have so it is the correct choice, as limiting as that can be!

--- a/dist/inc/classes/Replays.php
+++ b/dist/inc/classes/Replays.php
@@ -290,12 +290,21 @@ class Replays {
 
     public function getIcons() {
 
-        return file_get_contents('https://r3icons.titanmods.xyz/config.json');
+        return $this->my_curl('https://r3icons.titanmods.xyz/config.json');
     }
 
     public function getObjectiveMarkers() {
 
-        return file_get_contents('https://r3icons.titanmods.xyz/markers.json');
+        return $this->my_curl('https://r3icons.titanmods.xyz/markers.json');
+    }
+
+    function my_curl($url) {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER,1);
+        $data = curl_exec($ch);
+        curl_close($ch);
+        return $data;
     }
 
     public function getHtmlReplaysForPlayer($playerId, $replayData = FALSE) {

--- a/dist/playback.php
+++ b/dist/playback.php
@@ -24,7 +24,12 @@ $headerTitle = UNIT_NAME;
 $metaImage = WEB_PATH . '/maps/' . strtolower($replayDetails->map) . '/tiles/0/0/0.png';
 $page = 'playback';
 
-$mappingConfig = file_get_contents('https://r3tiles-a.titanmods.xyz/config.json');
+$url = 'https://r3tiles-a.titanmods.xyz/config.json';
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, $url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER,1);
+$mappingConfig = curl_exec($ch);
+curl_close($ch);
 
 $playerList = $replays->fetchReplayPlayers($_GET['replayId'], $replayDetails->playerList);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2'
+
+services:
+    db:
+        image: mariadb:10.1.26
+        container_name: r3_db
+        restart: always
+        environment:
+            MYSQL_USER: r3
+            MYSQL_PASSWORD: password
+            MYSQL_ROOT_PASSWORD: password
+            MYSQL_DATABASE: r3
+        volumes:
+            - r3_db_data:/var/lib/mysql
+        ports:
+            - "3306:3306"
+
+    web:
+        depends_on:
+          - db
+        build:
+          context: .
+          dockerfile: web.docker
+        image: local/r3_web
+        container_name: r3_web
+        restart: always
+        environment:
+          VIRTUAL_HOST: r3.local
+          DB_HOST: r3_db
+          DB_USER: r3
+          DB_PASSWORD: password
+          DB_NAME: r3
+        ports:
+          - "8080:80"
+        volumes:
+          - ./dist:/var/www/html/
+
+volumes:
+    r3_db_data:
+    dist:


### PR DESCRIPTION
Some other changes were thrown in for the readme, but those were just my editor removing left over white space which I think is fine to just accept.

Readme update is specific for linux, as you need to allow the web server user access to the cache directory to write the json files in.

`file_get_contents` isn't the best way to get files on a remote server, plus it doesn't seem to run that well at times. Curl is generally a better practice for PHP when obtaining remote files via HTTP or HTTPS protocols.

```
[Wed Oct 10 11:31:47.053350 2018] [php7:warn] [pid 17763] [client 5.151.214.0:48461] PHP Warning:  file_get_contents(https://r3icons.titanmods.xyz/markers.json): failed to open stream: Connection timed out in /srv/www/replays.7cav.us/public/inc/classes/Replays.php on line 298, referer: https://replays.7cav.us/
```