### PR TITLE
Add delete cascade for events

### DIFF
--- a/db-template.sql
+++ b/db-template.sql
@@ -1,80 +1,58 @@
+CREATE TABLE `replays` (
+    `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `missionName` VARCHAR(100) NULL DEFAULT NULL,
+    `slug` VARCHAR(120) NULL DEFAULT NULL,
+    `map` VARCHAR(50) NULL DEFAULT NULL,
+    `dayTime` FLOAT NULL DEFAULT NULL,
+    `playerCount` INT(11) NULL DEFAULT NULL,
+    `playerList` TEXT NULL,
+    `dateStarted` DATETIME NULL DEFAULT NULL,
+    `lastEventMissionTime` DATETIME NULL DEFAULT NULL,
+    `hidden` TINYINT(1) NULL DEFAULT '0',
+    `addonVersion` VARCHAR(10) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    INDEX `id` (`id`)
+)
+COLLATE='utf8_general_ci'
+ENGINE=InnoDB
+;
 
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
-/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
-/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
-
-
-# Dump of table events
-# ------------------------------------------------------------
 
 CREATE TABLE `events` (
-  `replayId` int(11) unsigned NOT NULL,
-  `playerId` varchar(60) DEFAULT NULL,
-  `type` varchar(50) DEFAULT NULL,
-  `value` longtext,
-  `missionTime` int(11) DEFAULT NULL,
-  `added` datetime DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
-  KEY `replayId` (`replayId`),
-  KEY `missionTime` (`missionTime`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+    `replayId` INT(11) UNSIGNED NOT NULL,
+    `playerId` VARCHAR(60) NULL DEFAULT NULL,
+    `type` VARCHAR(50) NULL DEFAULT NULL,
+    `value` LONGTEXT NULL,
+    `missionTime` INT(11) NULL DEFAULT NULL,
+    `added` DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+    INDEX `replayId` (`replayId`),
+    INDEX `missionTime` (`missionTime`),
+    CONSTRAINT `FK_events_replays` FOREIGN KEY (`replayId`) REFERENCES `replays` (`id`) ON DELETE CASCADE
+)
+COLLATE='utf8_general_ci'
+ENGINE=InnoDB
+;
 
-
-
-# Dump of table players
-# ------------------------------------------------------------
 
 CREATE TABLE `players` (
-  `id` varchar(60) NOT NULL DEFAULT '',
-  `name` varchar(50) DEFAULT NULL,
-  `lastSeen` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `id` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+    `id` VARCHAR(60) NOT NULL DEFAULT '',
+    `name` VARCHAR(50) NULL DEFAULT NULL,
+    `lastSeen` DATETIME NULL DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `id` (`id`)
+)
+COLLATE='utf8_general_ci'
+ENGINE=InnoDB
+;
 
-
-
-# Dump of table replays
-# ------------------------------------------------------------
-
-CREATE TABLE `replays` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `missionName` varchar(100) DEFAULT NULL,
-  `slug` varchar(120) DEFAULT NULL,
-  `map` varchar(50) DEFAULT NULL,
-  `dayTime` float DEFAULT NULL,
-  `playerCount` int(11) DEFAULT NULL,
-  `playerList` text,
-  `dateStarted` datetime DEFAULT NULL,
-  `lastEventMissionTime` datetime DEFAULT NULL,
-  `hidden` tinyint(1) DEFAULT '0',
-  `addonVersion` varchar(10) DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `id` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-
-
-
-# Dump of table shares
-# ------------------------------------------------------------
 
 CREATE TABLE `shares` (
-  `shareId` int(11) NOT NULL AUTO_INCREMENT,
-  `url` varchar(500) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `shared` datetime DEFAULT NULL,
-  `hits` int(11) DEFAULT '0',
-  PRIMARY KEY (`shareId`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-
-
-
-/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
-/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
-/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+    `shareId` INT(11) NOT NULL AUTO_INCREMENT,
+    `url` VARCHAR(500) NULL DEFAULT NULL,
+    `shared` DATETIME NULL DEFAULT NULL,
+    `hits` INT(11) NULL DEFAULT '0',
+    PRIMARY KEY (`shareId`)
+)
+COLLATE='utf8mb4_unicode_ci'
+ENGINE=InnoDB
+;


### PR DESCRIPTION
New Dump from a MariaDB database with an added FK Constraint on replayId.

The goal was to make deleting events easier. Now one just needs to delete the replay and the associated events get deleted automatically.

And I've changed the `id` column of the `replays` table to be `unsigned` (just like the `replayId` column of the `events` table)

Needed to change order of tables for the constraint to properly/reliably work.